### PR TITLE
fix crash when reading large user msg, refactor

### DIFF
--- a/public/chat.html
+++ b/public/chat.html
@@ -1,39 +1,49 @@
 <!DOCTYPE html>
 <html lang="en">
-
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="shortcut icon" href="./favicon.ico" type="image/x-icon">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.1/css/all.min.css"
-        integrity="sha256-mmgLkCYLUQbXn0B1SRqzHar6dCnv9oZFPEC1g1cwlkk=" crossorigin="anonymous" />
-    <link rel="stylesheet" href="css/common.css">
-    <link rel="stylesheet" href="css/chat.css">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="shortcut icon" href="./favicon.ico" type="image/x-icon" />
+    <link
+      rel="stylesheet"
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.1/css/all.min.css"
+      integrity="sha256-mmgLkCYLUQbXn0B1SRqzHar6dCnv9oZFPEC1g1cwlkk="
+      crossorigin="anonymous"
+    />
+    <link rel="stylesheet" href="css/common.css" />
+    <link rel="stylesheet" href="css/chat.css" />
     <script src="/socket.io/socket.io.min.js" defer></script>
     <script src="js/chat.js" defer></script>
     <title>NoChat - Chat</title>
-</head>
+  </head>
 
-<body>
+  <body>
     <div id="container">
-        <header id="header">
-            <h1>NoChat&nbsp;<i class="fas fa-comment-dots"></i></h1>
-            <a href="index.html" class="btn">Leave</a>
-        </header>
-        <div id="main">
-            <div id="sidebar">
-                <h3>Users&nbsp<i class="fas fa-user-friends"></i></h3>
-                <ul id="users"></ul>
-            </div>
-            <div id="messages"></div>
+      <header id="header">
+        <h1>NoChat&nbsp;<i class="fas fa-comment-dots"></i></h1>
+        <a href="index.html" class="btn">Leave</a>
+      </header>
+      <div id="main">
+        <div id="sidebar">
+          <h3>Users&nbsp<i class="fas fa-user-friends"></i></h3>
+          <ul id="users"></ul>
         </div>
-        <div id="form-container">
-            <form id="form">
-                <input id="message-input" type="text" placeholder="Enter your message..." autocomplete="off" required />
-                <button id="send-btn" class="btn">Send&nbsp;<i class="fas fa-share"></i></button>
-            </form>
-        </div>
+        <div id="messages"></div>
+      </div>
+      <div id="form-container">
+        <form id="form">
+          <input
+            id="message-input"
+            type="text"
+            placeholder="Enter your message..."
+            autocomplete="off"
+            required
+          />
+          <button id="send-btn" class="btn">
+            Send&nbsp;<i class="fas fa-share"></i>
+          </button>
+        </form>
+      </div>
     </div>
-</body>
-
+  </body>
 </html>

--- a/public/css/chat.css
+++ b/public/css/chat.css
@@ -75,6 +75,9 @@
 .incoming-message {
   background-color: var(--accent-color);
 }
+.message {
+  word-wrap: break-word;
+}
 
 .message,
 .meta {

--- a/public/js/chat.js
+++ b/public/js/chat.js
@@ -1,3 +1,5 @@
+const MAX_MESSAGE_LENGTH = 500;
+
 // socket.io server event IDs
 const EV_MESSAGE = "message";
 const EV_CHAT_MESSAGE = "chat_message";
@@ -36,9 +38,13 @@ socket.on(EV_USERS, (usernameList) => {
 chatForm.addEventListener(EV_SUBMIT, (e) => {
   e.preventDefault();
 
-  const msg = messageInput.value.trim();
+  let msg = messageInput.value.trim();
 
   if (msg === "") return;
+
+  if (msg.length > MAX_MESSAGE_LENGTH) {
+    msg = msg.substring(0, MAX_MESSAGE_LENGTH) + "...";
+  }
 
   socket.emit(EV_CHAT_MESSAGE, msg);
 


### PR DESCRIPTION
## Major changes
When users sent huge messages, the socket crashed.

Fixed by limitting user input on client-side, as well as adding try/catch clauses in the backend (in case of bypass).

## Other changes
- added word wrap to messages, so they do not overflow
- added try/catch in most possible error sources, to prevent crashing
- added more logging to facilitate post-mortem debugging 
